### PR TITLE
Decisions and actions

### DIFF
--- a/lib/farmjs.js
+++ b/lib/farmjs.js
@@ -19,7 +19,6 @@ exports.HEADERS = {
     URL: 'x-farmjs-url',
     REQID: 'x-farmjs-reqid',
     APP: 'x-farmjs-app',
-    APP_FULLNAME: 'x-farmjs-app-fullname',
     INSTANCE: 'x-farmjs-instance',
 };
 
@@ -34,7 +33,7 @@ function Router(opts) {
 
     opts.logger = ctxcon(opts.logger || console);
     opts.resolver = opts.resolver || new Resolver();
-    if (!opts.getAppByName) throw new Error('getAppByName not defined');
+    if (!opts.decide) throw new Error('"decide" function is not defined');
     if (!opts.getInstances) throw new Error("getInstances not defined");
     if (!('authPrivate' in opts)) opts.authPrivate = true;
 
@@ -80,11 +79,11 @@ function Router(opts) {
     self.proxy = new httpProxy.RoutingProxy();
 
     //
-    // getAppByName is used to look up for apps
+    // decide is used to decide how to handle a request
     //
 
-    self.getAppByName = opts.getAppByName;
-    delete opts.getAppByName;
+    self.decide = opts.decide;
+    delete opts.decide;
 
     //
     // getInstances is used to look up instances
@@ -99,6 +98,17 @@ function Router(opts) {
     //
 
     self.options = opts;
+
+    //
+    // Install default action handlers
+    //
+
+    self._actionHandlers = {};
+    self.install('error', self._errorAction);
+    self.install('spawn', self._spawnAction);
+    self.install('proxy', self._proxyAction);
+    self.install('redirect', self._redirectAction);
+    self.install('alias', self._aliasAction);
 
     return self;
 };
@@ -131,6 +141,27 @@ Router.prototype.connect = function(optionsOverride) {
     return app;
 };
 
+/**
+ * Installs an action handler.
+ * Action handles are invoked based on the result of a `decide` call. The `{action:{...}}`
+ * structure within the result may contain a single key, which is the action type.
+ * `actionHandler` is `function(action, req, res, next)` and may use the extended API of `req` and `res`
+ * to handle the request. `next` is provided to allow forfitting the action, but this will usually not work.
+ * Only a single handler may be installed per action type.
+ */
+Router.prototype.install = function(actionType, actionHandler) {
+    var self = this;
+
+    if (actionType in self._actionHandlers) throw new Error("there is already a handler for action type " + actionType);
+
+    self._actionHandlers[actionType] = actionHandler;
+
+    return true;
+};
+
+/**
+ * Shuts down any spawned child processes
+ */
 Router.prototype.close = function(callback) {
     var self = this;
     self.logger.info("Closing farm");
@@ -145,8 +176,11 @@ Router.prototype.addParentDomain = function(domain) {
     var self = this;
     self.resolver.addRootDomain(domain);
     return self;
-}
+};
 
+/**
+ * This is the request pipeline
+ */
 Router.prototype._handlers = {
 
     /**
@@ -198,7 +232,7 @@ Router.prototype._handlers = {
             var logline = "HTTP";
             logline += " " + res.statusCode;
             logline += " " + req.method;
-            logline += " " + req.app.name;
+            logline += " " + req.purl.app;
             logline += " " + req.url;
             if (res.statusCode === 302) logline += " REDIRECT " + res.getHeader('location');
             logline += " " + latency + "ms";
@@ -272,6 +306,10 @@ Router.prototype._handlers = {
         req.purl = self._parseURL(req);
         req.url = req.purl.path; // update url on request
         req.hints = req.purl.hints; // make hints more accessible
+
+        // add the 'x-farmjs-app' header
+        if (req.purl.app) req.headers[exports.HEADERS.APP] = req.purl.app;
+
         next();
     },
 
@@ -295,21 +333,21 @@ Router.prototype._handlers = {
     
     alias: function(req, res, next) {
         var self = this;
-        if (!req.app.alias) return next();
-        self._lookupAppHandler(req.app.alias.target, req, res, next);
+        if (!req.decision.action.alias) return next();
+        self._lookupAppHandler(req.decision.action.alias.target, req, res, next);
     },
 
     /**
      * Redirect apps marked as { secure: true } to their https:// counterpart
      */
-    httpsRedirect: function(req, res, next) {
+    secure: function(req, res, next) {
         if (req.secure) return next(); // we are in 'https', nothing to do
 
         // if https-only is required by the app, redirect to the https counterpart
         // of the same url.
-        if (req.app.secure) {
+        if (req.decision.secure) {
             var location = 'https://' + req.headers.host + req.purl.original;
-            req.logger.log('secure app accessed via HTTP. redirecting to HTTPS: ', req.app.name, location);
+            req.logger.log('secure app accessed via HTTP. redirecting to HTTPS: ', req.purl.app, location);
             return res.redirect(location);
         }
 
@@ -332,7 +370,7 @@ Router.prototype._handlers = {
         // If this app is marked as 'public', continue
         //
 
-        if (req.app.public) return next();
+        if (req.decision.public) return next();
 
         //
         // App is private, check if an authorized client cert has been presented
@@ -341,7 +379,7 @@ Router.prototype._handlers = {
         //TODO: Maybe we should use request.connection.verifyPeer() here?
         req.logger.log("App requires client certificate authentication because it is not marked as 'public'");
         var requestIsAuthenticated = req.client && req.client.pair && req.client.pair.cleartext && req.client.pair.cleartext.authorized;
-        if (!requestIsAuthenticated) return res.error(401, "Forbidden: '" + req.app.name + "' requires an authenticated client");
+        if (!requestIsAuthenticated) return res.error(401, "Forbidden: '" + req.purl.app + "' requires an authenticated client");
         req.logger.log("Client certificate found");
 
         //
@@ -349,15 +387,10 @@ Router.prototype._handlers = {
         //
 
         return next();
-    },
-
-    blocked: function(req, res, next) {
-        if (!req.app.blocked) return next();
-        return res.error(403, req.app.blocked);
-    },
+	},
 
     /**
-     * $inst/x-famrjs-instance: Proxy request to a different farm instance
+     * $inst/x-farmjs-instance: Proxy request to a different farm instance
      */
     inst: function(req, res, next) {
         var self = this;
@@ -421,86 +454,25 @@ Router.prototype._handlers = {
 
     },
 
-    /**
-     * Redirect request to app dashboard
-     */
-    dash: function(req, res, next) {
-        if (!('$dash' in req.hints || '$log' in req.hints)) return next();
-        return res.end('redirect to dashboard');
-    },
-
-    /**
-     * Spawn - if app.spawn is defined, we will spawn the script defined in it, allocating a port and
-     * then proxy the request to this newly spawnned process.
-     */
-    spawn: function(req, res, next) {
+    //
+    // This stage basically performs the action based on the only key in `decision.action`.
+    // Actions are middleware arrays installed using router.install(actionHandler).
+    // Handlers are `function(req, res, next)`
+    //
+    performAction: function(req, res, next) {
         var self = this;
-
-        if (!req.app.spawn) return next();
-
-        //
-        // Spin it up, dambo!
-        //
-
-        req.logger.log('Spinning', req.app.spawn.command, req.app.spawn.args);
-        
-        // create spinner options by cloning req.app.spawn
-        var options = { };
-        for (var k in req.app.spawn) options[k] = req.app.spawn[k];
-        options.logger = req.logger;
-
-        // add some env variables
-        options.env = options.env || {};
-        options.env.FARMJS_APP = req.app.basename;
-        options.env.FARMJS_APP_FULLNAME = req.app.name;
-        options.env.FARMJS_INSTANCE = req.options.instance;
-
-        self.spinner.start(options, function(err, port) {
-            if (err) return res.error(500, new Error("unable to spawn app " + req.app.name + ". " + err.toString()));
-
-            //
-            // Proxy the request to the spawned process
-            //
-
-            req.logger.log("Script spawned and accessible via", port);
-            return res.proxy(port);
-        }, req.logger);
+        var type = Object.keys(req.decision.action)[0];
+        var handler = self._actionHandlers[type];
+        if (!handler) return error(500, "Unable to find handler for action type " + type);
+        return handler.call(self, req.decision.action[type], req, res, next);
     },
 
-    /**
-     * Proxy - app.proxy is defined, we will just proxy the request to `host`:`port` with `headers`.
-     */
-    proxy: function(req, res, next) {
-        var self = this;
-
-        if (!req.app.proxy) return next();
-
-        if (!req.app.proxy.host) req.app.proxy.host = "localhost";
-        if (!req.app.proxy.port) return res.error(500, "Cannot proxy app without a port");
-        if (!req.app.proxy.headers) req.app.proxy.headers = {};
-
-        //
-        // Add headers
-        //
-
-        var headers = req.app.proxy.headers;
-        for (var h in headers) req.headers[h] = headers[h];
-
-        //
-        // Proxy
-        //
-
-        return res.proxy(req.app.proxy.port, req.app.proxy.host);
-    },
-
+    //
+    // This middleware basically returns 404 on anything not handled so far
+    //
     catchall: function(req, res, next) {
-        res.error(404, "Not found");
+        return res.error(404, "Not found");
     },
-
-    /**
-     * Handle all errors, the connect way
-     */
-    errors: express.errorHandler({ showStack: true, dumpExceptions: true }),
 };
 
 /**
@@ -533,19 +505,80 @@ Router.prototype._createMiddleware = function(handlerName, handlerFn, options) {
 
 /**
  * Handle for app lookup
+ * Decision structure:
+ *
+ *       var decision = {
+ *           secure: false,  // 'true' will redirect HTTP connections to their HTTPS counterparts (default: false)
+ *           public: false,  // 'false' will allow accessing the app only via the HTTPS endpoint with a client cert (default: false)
+ *
+ *           // action may contain only one of the below options
+ *           action: { 
+ *               spawn: {
+ *                   command: {string}
+ *                   args: [ {string} ]
+ *               },
+ *               proxy: {
+ *                  host: {string} (optional, default 'localhost')
+ *                   port: {number}
+ *                   headers: {hash} (optional)
+ *               },
+ *               redirect: {
+ *                   location: {url}
+ *               }
+ *               alias: {
+ *                   app: {string}
+ *               },
+ *               block: {
+ *                   [message: {string}]
+ *               },
+ *               error: {
+ *                   status: {number}
+ *                   [headers: {hash}]
+ *                   [message: {string}]
+ *               }
+ *           }
+ *       }
+ *
  */
 Router.prototype._lookupAppHandler = function(name, req, res, next) {
     var self = this;
-    self.getAppByName(req.logger, name, function(err, app) {
-        if (err || !app) return res.error(404, err || "app '" + name + "' not found");
+    
+    return self.decide(req, name, function(err, decision) {
+        if (err || !decision) return res.error(404, err || "app '" + name + "' not found");
 
-        // overload app info on request and create x-farmjs-app header.                     
-        req.app = app;
-        req.headers[exports.HEADERS.APP] = req.app.basename;
-        req.headers[exports.HEADERS.APP_FULLNAME] = req.app.name;
+        //
+        // verify that the decision is well-formed.
+        //
 
-        next();
-    }); 
+        req.logger.log('Decision:', JSON.stringify(decision));
+
+        //
+        // verify that we only have a single action
+        //
+
+        if (Object.keys(decision.action).length !== 1) {
+            return res.error(500, "decision for app " + name + " needs to contain exactly one verb");
+        }
+
+        //
+        // verify that the action is one of the allowed actions
+        //
+
+
+
+        var verb = Object.keys(decision.action)[0];
+        if (!(verb in self._actionHandlers)) {
+            return res.error(500, "action '" + verb + "' not one of: " + JSON.stringify(Object.keys(self._actionHandlers)));
+        }
+
+        //
+        // store decision on request bus
+        //
+
+        req.decision = decision;
+
+        return next();
+    });
 };
 
 /**
@@ -682,7 +715,8 @@ Router.prototype._prepareRequestsForBroadcast = function(req, callback) {
             // prepare headers
             var headers = {};
             for (var k in req.headers) headers[k] = req.headers[k];
-            headers[exports.HEADERS.APP] = req.app.name; // override app via header (because we can't use hostname for that)
+
+            headers[exports.HEADERS.APP] = req.purl.app; // override app via header (because we can't use hostname for that)
             delete headers[exports.HEADERS.URL]; // do not repeat URL override
 
             return {
@@ -698,7 +732,112 @@ Router.prototype._prepareRequestsForBroadcast = function(req, callback) {
 
         callback(null, requests);
     });
-}
+};
+
+/**
+ * Error Action
+ * Allows responding with arbitrary http status codes.
+ */
+Router.prototype._errorAction = function(params, req, res, next) {
+    var self = this;
+
+    //
+    // Copy headers, if provided
+    //
+    if (params.headers) for (var k in params.headers) res.headers[k] = params.headers[k];
+
+    //
+    // Respond with an error
+    //
+
+    return res.error(params.status, params);
+};
+
+/**
+ * Spawn Action
+ * If this action is defined, we will spawn the script defined in it, allocating a port and
+ * then proxy the request to this newly spawnned process.
+ */
+Router.prototype._spawnAction = function(params, req, res, next) {
+    var self = this;
+
+    //
+    // Spin it up, dambo!
+    //
+
+    req.logger.log('Spinning', params.command, params.args);
+    
+    // create spinner options by cloning params as-is
+    var options = { };
+    for (var k in params) options[k] = params[k];
+    
+    // set name
+    options.name = req.purl.app;
+
+    // set logger
+    options.logger = req.logger;
+
+    // add some env variables
+    options.env = options.env || {};
+    options.env.FARMJS_APP = req.purl.app;
+    options.env.FARMJS_INSTANCE = req.options.instance;
+
+    return self.spinner.start(options, function(err, port) {
+        if (err) return res.error(500, new Error("unable to spawn app " + req.purl.app + ". " + err.toString()));
+
+        //
+        // Proxy the request to the spawned process
+        //
+
+        req.logger.log("Script spawned and accessible via", port);
+        return res.proxy(port);
+    }, req.logger);
+};
+
+/**
+ * Proxy Action
+ * This allows to proxy the request to `host`:`port` with `headers`.
+ */
+Router.prototype._proxyAction = function(params, req, res, next) {
+    var self = this;
+
+    if (!params.port) return res.error(500, "Cannot proxy app without a port");
+
+    var host = params.host || "localhost";
+    var port = params.port;
+    var headers = params.headers || {};
+
+    //
+    // Add headers
+    //
+
+    for (var h in headers) req.headers[h] = headers[h];
+
+    //
+    // Proxy
+    //
+
+    return res.proxy(port, host);
+};
+
+/**
+ * Redirect Action
+ */
+Router.prototype._redirectAction = function(params, req, res, next) {
+    if (!params.location) return error(500, "redirect action must contain a 'location' parameter");
+    return res.redirect(params.location);
+};
+
+/**
+ * Alias Action
+ * In fact, 'alias' is resolved before authentication, so this handler is fake, to keep validation code happy.
+ * At a later stage we can model "pre-authentication" and "post-authentication" actions so it will be first-class.
+ */
+Router.prototype._aliasAction = function(params, req, res, next) {
+    return res.error(500, "alias should have been resolved at an earlier stage");
+};
+
+// ------ Module API
 
 /**
  * Creates a farm.js router Express middleware

--- a/test/lib/cases.js
+++ b/test/lib/cases.js
@@ -74,7 +74,7 @@ exports.tests = [
     { 
         from: 'http://direct-alias.anodejs.org/1234588', 
         expected: {
-            authHttps: { spawn: '$/master/apps/direct/.shimmed.v2.index.js', url: '/1234588', app: 'direct' },
+            authHttps: { spawn: '$/master/apps/direct/.shimmed.v2.index.js', url: '/1234588', app: 'direct-alias' },
         },
     },
 
@@ -97,7 +97,7 @@ exports.tests = [
     { 
         from: 'http://foogoo.branch9.anodejs.org', 
         expected: {
-            authHttps: { spawn: '$/branch9/apps/foogoo/.shimmed.v2.index.js', url: '/', app: 'foogoo' },
+            authHttps: { spawn: '$/branch9/apps/foogoo/.shimmed.v2.index.js', url: '/', app: 'foogoo.branch9' },
         },
     },
 

--- a/test/lib/instman.js
+++ b/test/lib/instman.js
@@ -240,7 +240,7 @@ InstanceManager.prototype.start = function(index, callback) {
                 logger: self.logger.pushctx(id), 
                 instance: id,
                 range: spinnerRange,
-                getAppByName: appresolver(port, id),
+                decide: appresolver(port, id),
                 getInstances: function(callback) {
                     var instances = {};
                     for (var id in self.instances) {

--- a/test/lib/testhttphandler.js
+++ b/test/lib/testhttphandler.js
@@ -7,8 +7,7 @@ module.exports = function(extend) {
         req.on('end', function() {
             var echo = {
                 bodyLength: len,
-                appname: process.env.FARMJS_APP_FULLNAME || req.headers['x-farmjs-app'],
-                appbasename: process.env.FARMJS_APP || req.headers['x-farmjs-app-fullname'],
+                appname: process.env.FARMJS_APP || req.headers['x-farmjs-app'],
                 inst: process.env.FARMJS_INSTANCE,
                 port: process.env.PORT,
                 argv: process.argv,

--- a/test/parseurl.test.js
+++ b/test/parseurl.test.js
@@ -8,7 +8,7 @@ exports.parseURL = {
     setUp: function(cb) {
         var server = farmjs.createRouter({ 
             instance: 'inst0', 
-            getAppByName: function() { }, 
+            decide: function() { }, 
             getInstances:function() { },
         });
 

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -158,7 +158,7 @@ tests.all = function(test) {
 
                         if (expected.app) {
                             self.equals(test, c, echo.headers[farmjs.HEADERS.APP], expected.app, "Expecting app to be " + expected.app);
-                            self.equals(test, c, echo.appbasename, expected.app, "Expecting app to be " + expected.app);
+                            self.equals(test, c, echo.appname, expected.app, "Expecting app to be " + expected.app);
                         }
 
                         if (expected.spawn) {

--- a/test/simple.test.js
+++ b/test/simple.test.js
@@ -17,7 +17,7 @@ exports.simple = testCase({
             var options = {
                 instance: 'one',
                 authPrivate: false,
-                getAppByName: appresolver(8090),
+                decide: appresolver(8090),
                 getInstances: function(cb) { return cb(null, {}); },
                 logger: logule,
             };


### PR DESCRIPTION
Instead of `getAppByName` (which, by the name you can figure out how temporary it was), require a 'decide' function (even a worse name, but looks nice).

The `decide` function has the following signature: `function(req, name callback)` where `callback` is `function(err, decision)`. The decision has the following format:

``` js
{
    // indicates if this app requires client authentication
    public: true | false,

    // indicates if this app will have https redirection on http calls
    secure: true | false,

    // the action to perform for this app
    action: { ... }
}
```

The `action` property may contain a single key that determines the "result" of the routing decision. A routing action is a `function(params, req, res, next)` where `params` are parameters returned by the `decide()` function and `req`, `res` and `next` are middleware functions. `req` and `res` are express.js request and response objects overloaded with some farmjs goodies:
- **req.reqid** - The uuid of the request, allocated per request and also added in the response header `x-farmjs-reqid`
- **req.logger** - A console-like contextual logger. Use it to emit logs in the context of handling this request
- **req.secure** - `true` if this is an HTTPS request
- **req.hints** - A hash of '$' hints passed in the query string.
- **res.error(status, obj)** - Will end the request with `status` HTTP status and `obj` as JSON output.
- **res.proxy(port, host)** - Will proxy the request to host:port and end it. If you wish to add headers to the _response_, emit them before calling `res.proxy()`

Action handlers can be installed using: `router.install(type, handler)` where `type` is the key in the `action` property of the decision.

The router is automatically installed with the following actions.

Spawns a child process with env.PORT allocation and proxy request to it

``` js
action: {
    spawn: {
        // program to execute (defaults to node)
        command: process.execPath

        // environment variables to bind to the child process
        // farmjs will automatically add FARMJS_APP and FARMJS_INSTANCE
        env: { },

        // working directory for the child process
        cwd: null,

        // any other options passed to [spinner](https://github.com/anodejs/node-spinner)
        ...
    }
}
```

Proxy the request to some host:port

``` js
action: {
    proxy: {
        host: 'localhost',
        port: ...,
        headers: { }
    }
}
```

End the request with an HTTP status code

``` js
action: {
    error: {
        status: ..., // http status code

        // any other fields will be emitted in the application/json response
    }
}
```

``` js
action: {
    redirect: {
        location: ..., // href to redirect to
    }
}
```

This action will cause farmjs to re-issue a `decide()` call with the `target` as the name of the name
of the app being looked up. This essentially allows easily aliasing apps be just emitting an alias action
to the target app.

``` js
action: {
    alias: {
        target: ..., // name of app to alias
    }
}
```
